### PR TITLE
Fix zsyncmake freezing on macOS

### DIFF
--- a/src/service/zsync/zsyncmake.spec.ts
+++ b/src/service/zsync/zsyncmake.spec.ts
@@ -12,7 +12,7 @@ describe(zsyncmake.name, () => {
 
         await zsyncmakeWithExec('/needs-update', (cmd, callback) => {cmdLine = cmd; callback(null, {stdout: '', stderr: ''});});
 
-        expect(cmdLine).toBe('zsyncmake -eu "http://foo/needs-update" "/var/lib/repo/needs-update" -o "/var/lib/repo/needs-update.zsync"');
+        expect(cmdLine).toBe('zsyncmake -eu "http://foo/needs-update" -o "/var/lib/repo/needs-update.zsync" "/var/lib/repo/needs-update"');
         done();
     })
 });

--- a/src/service/zsync/zsyncmake.ts
+++ b/src/service/zsync/zsyncmake.ts
@@ -16,7 +16,7 @@ function checkPath(file: Path) {
 }
 
 function getCmdLine(publicURL: string, rootPath: Path, file: Path): string {
-    return `zsyncmake -eu "${publicURL}${file}" "${rootPath}${file}" -o "${rootPath}${file}.zsync"`;
+    return `zsyncmake -eu "${publicURL}${file}" -o "${rootPath}${file}.zsync" "${rootPath}${file}"`;
 }
 
 export async function zsyncmake(file: Path): Promise<void> {


### PR DESCRIPTION
If `-o` parameter is used after input file zsyncmake freezes on macOS