### PR TITLE
fix: zsyncmake crashing when filename contains $

### DIFF
--- a/src/service/zsync/zsyncmake.spec.ts
+++ b/src/service/zsync/zsyncmake.spec.ts
@@ -12,7 +12,7 @@ describe(zsyncmake.name, () => {
 
         await zsyncmakeWithExec('/needs-update', (cmd, callback) => {cmdLine = cmd; callback(null, {stdout: '', stderr: ''});});
 
-        expect(cmdLine).toBe('zsyncmake -eu "http://foo/needs-update" -o "/var/lib/repo/needs-update.zsync" "/var/lib/repo/needs-update"');
+        expect(cmdLine).toBe("zsyncmake -eu 'http://foo/needs-update' -o '/var/lib/repo/needs-update.zsync' '/var/lib/repo/needs-update'");
         done();
     })
 });

--- a/src/service/zsync/zsyncmake.ts
+++ b/src/service/zsync/zsyncmake.ts
@@ -16,7 +16,7 @@ function checkPath(file: Path) {
 }
 
 function getCmdLine(publicURL: string, rootPath: Path, file: Path): string {
-    return `zsyncmake -eu "${publicURL}${file}" -o "${rootPath}${file}.zsync" "${rootPath}${file}"`;
+    return `zsyncmake -eu '${publicURL}${file}' -o '${rootPath}${file}.zsync' '${rootPath}${file}'`;
 }
 
 export async function zsyncmake(file: Path): Promise<void> {


### PR DESCRIPTION
If a folder contains `$PBOPREFIX$` or similar name the zsyncmake call fails

```
Error while truncating /data/@3den_enhanced/python_code/$PYTHIA$ [Error: ENOENT: no such file or directory, stat '/data/@3den_enhanced/python_code/$PYTHIA$'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/data/@3den_enhanced/python_code/$PYTHIA$'
}
Error while truncating /data/@3den_enhanced/python_code/__init__.py [Error: ENOENT: no such file or directory, stat '/data/@3den_enhanced/python_code/__init__.py'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/data/@3den_enhanced/python_code/__init__.py'
}
```